### PR TITLE
Update AutoMapper dependency

### DIFF
--- a/.github/workflows/buildandpublish.yml
+++ b/.github/workflows/buildandpublish.yml
@@ -22,10 +22,10 @@ jobs:
       with:
         dotnet-version: '3.1.100'
     - name: Build with dotnet
-      run: dotnet build src/JHipsterNet.sln --configuration Release /p:Version=1.0.4
+      run: dotnet build src/JHipsterNet.sln --configuration Release /p:Version=1.0.5
     - name: Pack JHipsterNet.Core with dotnet
-      run: dotnet pack src/JHipsterNet.Core/JHipsterNet.Core.csproj --output nuget-packages --configuration Release --include-symbols -p:PackageVersion=1.0.4
+      run: dotnet pack src/JHipsterNet.Core/JHipsterNet.Core.csproj --output nuget-packages --configuration Release --include-symbols -p:PackageVersion=1.0.5
     - name: Pack JHipsterNet.Web with dotnet
-      run: dotnet pack src/JHipsterNet.Web/JHipsterNet.Web.csproj --output nuget-packages --configuration Release --include-symbols -p:PackageVersion=1.0.4
+      run: dotnet pack src/JHipsterNet.Web/JHipsterNet.Web.csproj --output nuget-packages --configuration Release --include-symbols -p:PackageVersion=1.0.5
     - name: Push with dotnet
       run: dotnet nuget push '**/*.nupkg' --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/src/JHipsterNet.Core/JHipsterNet.Core.csproj
+++ b/src/JHipsterNet.Core/JHipsterNet.Core.csproj
@@ -12,7 +12,7 @@
 
     <ItemGroup>
         <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-        <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="7.0.0" />
+        <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.0.1" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.5" />
     </ItemGroup>
 

--- a/src/JHipsterNet.Web/JHipsterNet.Web.csproj
+++ b/src/JHipsterNet.Web/JHipsterNet.Web.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="LanguageExt.Core" Version="3.4.15" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Serilog" Version="2.9.0" />
-    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="7.0.0" />
+    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.5" />
   </ItemGroup>
 


### PR DESCRIPTION
This PR is for updating the AutoMapper dependency version.

After this PR is merged and the new version of this library gets published, we are going to update dependency versions as  https://github.com/jhipster/jhipster-dotnetcore/pull/410 states.