### PR TITLE
fixed integer division in page size calculation

### DIFF
--- a/src/JHipsterNet.Core/Pagination/IPageable.cs
+++ b/src/JHipsterNet.Core/Pagination/IPageable.cs
@@ -1,3 +1,5 @@
+ using JHipsterNet.Core.Pagination.Extensions;
+
 namespace JHipsterNet.Core.Pagination {
     public static class PageableConstants {
         public static readonly IPageable UnPaged = new UnPaged();
@@ -27,9 +29,9 @@ namespace JHipsterNet.Core.Pagination {
 
         public bool HasPrevious => false;
 
-        public int PageNumber => -1;
-        public int PageSize => -1;
+        public int PageNumber => 0;
+        public int PageSize => PageableBinderConfig.DefaultMaxPageSize;
 
-        public int Offset => -1;
+        public int Offset => 0;
     }
 }

--- a/src/JHipsterNet.Core/Pagination/Page.cs
+++ b/src/JHipsterNet.Core/Pagination/Page.cs
@@ -13,7 +13,7 @@ namespace JHipsterNet.Core.Pagination {
 
         public new bool IsLast => !HasNext;
 
-        public int TotalPages => Size == 0 ? 1 : Total / Size;
+        public int TotalPages => Size == 0 ? 1 : (Total / Size) + (Total % Size > 0 ? 1 : 0);
 
         public int TotalElements => Total;
     }


### PR DESCRIPTION
Currently, the TotalPages calculation uses integer division which means that the count is too low when the Total is not a multiple of Size. e.g. 21 / 20 -> 1 instead of 2